### PR TITLE
fix

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/kmlg_shuttle_lost.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/kmlg_shuttle_lost.yml
@@ -242,11 +242,6 @@ entities:
     - type: RadiationGridResistance
 - proto: AirCanister
   entities:
-  - uid: 141
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
   - uid: 142
     components:
     - type: Transform
@@ -627,6 +622,71 @@ entities:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
 - proto: CableTerminal
   entities:
   - uid: 149
@@ -686,7 +746,7 @@ entities:
   - uid: 212
     components:
     - type: Transform
-      pos: -2.5,-7.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 213
     components:
@@ -708,20 +768,10 @@ entities:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 217
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
   - uid: 218
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 1
-  - uid: 219
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
       parent: 1
 - proto: ChairOfficeDark
   entities:
@@ -744,14 +794,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
-      parent: 1
-- proto: ComputerAlert
-  entities:
-  - uid: 221
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-7.5
       parent: 1
 - proto: ComputerCargoBounty
   entities:
@@ -1052,6 +1094,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
 - proto: GasPipeStraight
   entities:
   - uid: 119
@@ -1157,11 +1204,6 @@ entities:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
   - uid: 137
     components:
     - type: Transform
@@ -1188,12 +1230,6 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 102
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 1
   - uid: 103
     components:
     - type: Transform
@@ -1267,7 +1303,14 @@ entities:
       pos: -6.5,-6.5
       parent: 1
     - type: PowerSupplier
-      supplyRate: 50000
+      supplyRate: 70000
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
 - proto: Grille
   entities:
   - uid: 60
@@ -1383,6 +1426,13 @@ entities:
     components:
     - type: Transform
       pos: -5.5,4.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
       parent: 1
 - proto: KMLGAirlockLocked
   entities:
@@ -2050,5 +2100,11 @@ entities:
     components:
     - type: Transform
       pos: -0.5,3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-6.5
       parent: 1
 ...

--- a/Resources/Maps/avanpost11_station.yml
+++ b/Resources/Maps/avanpost11_station.yml
@@ -6314,7 +6314,7 @@ entities:
       pos: 45.5,-2.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -23299.154
+      secondsUntilStateChange: -23614.658
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -74168,12 +74168,6 @@ entities:
     - type: Transform
       pos: 45.5,-22.5
       parent: 2
-  - uid: 4311
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 39.5,-17.5
-      parent: 2
   - uid: 4312
     components:
     - type: Transform
@@ -74195,12 +74189,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-22.5
-      parent: 2
-  - uid: 4316
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,-17.5
       parent: 2
   - uid: 5361
     components:
@@ -75916,6 +75904,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 59.5,48.5
+      parent: 2
+  - uid: 18140
+    components:
+    - type: Transform
+      pos: 40.5,-16.5
       parent: 2
 - proto: PoweredlightOrange
   entities:
@@ -80405,57 +80398,83 @@ entities:
       parent: 2
 - proto: SinkEmpty
   entities:
+  - uid: 4311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 75.5,-13.5
+      parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 9901
     components:
     - type: Transform
       pos: 65.5,1.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 9902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-2.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,36.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,36.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,36.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 66.5,36.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 80.5,30.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11595
     components:
     - type: Transform
       pos: 61.5,29.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11596
     components:
     - type: Transform
       pos: 62.5,29.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11597
     components:
     - type: Transform
@@ -80468,11 +80487,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 61.5,18.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11633
     components:
     - type: Transform
       pos: 74.5,45.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11634
     components:
     - type: Transform
@@ -80485,6 +80508,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 65.5,46.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
+  - uid: 18138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-17.5
+      parent: 2
+    missingComponents:
+    - SolutionRegeneration
+  - uid: 18139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 39.5,-17.5
+      parent: 2
+    missingComponents:
+    - SolutionRegeneration
 - proto: SiPlazCircuitBord1
   entities:
   - uid: 4714
@@ -81703,6 +81744,13 @@ entities:
     components:
     - type: Transform
       pos: 75.5,-5.5
+      parent: 2
+- proto: SpawnPointObserver
+  entities:
+  - uid: 4316
+    components:
+    - type: Transform
+      pos: 58.5,17.5
       parent: 2
 - proto: SpawnPointParamedic
   entities:
@@ -84621,21 +84669,29 @@ entities:
     - type: Transform
       pos: 61.5,39.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11259
     components:
     - type: Transform
       pos: 63.5,39.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11260
     components:
     - type: Transform
       pos: 65.5,39.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
   - uid: 11261
     components:
     - type: Transform
       pos: 67.5,39.5
       parent: 2
+    missingComponents:
+    - SolutionRegeneration
 - proto: ToiletGoldenDirtyWater
   entities:
   - uid: 583


### PR DESCRIPTION
## Описание PR
Фикс шаттла в событии с шаттлом Космологистики.
Фикс раковин и спавна наблюдателей на карте Аванпост 11.

## Почему / Баланс
Багофиксы!

## Технические детали
Файлы карт.

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения
Ничего критического.

**Список изменений**
:cl:
- add: Добавлен спавн наблюдателей на карту Аванпост 11.
- tweak: Изменены раковины и унитазы на карте Аванпост 11. В начале будет немножко воды.
- fix: Исправлен шаттл Космологистики из события с ним. теперь там есть питание и гравитация.
