### PR TITLE
Бутылка "Ничего" в лодаут бармена

### DIFF
--- a/Resources/Locale/ru-RU/victoria/bartender-loadouts.ftl
+++ b/Resources/Locale/ru-RU/victoria/bartender-loadouts.ftl
@@ -1,0 +1,1 @@
+loadout-group-bartender-drinks = Бармен, напитки

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -59,6 +59,7 @@
   - BartenderJumpsuit
   - CommonBackpack
   - BartenderOuterClothing
+  - BartenderDrinks
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Victoria/Bartender-loadout-drinks/loadout.yml
+++ b/Resources/Prototypes/Victoria/Bartender-loadout-drinks/loadout.yml
@@ -1,0 +1,24 @@
+- type: loadoutEffectGroup
+  id: BottleOfNothingTimer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 3600
+
+- type: loadout
+  id: BottleOfNothing
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: BottleOfNothingTimer
+  storage:
+    back:
+    - DrinkBottleOfNothingFull
+
+- type: loadoutGroup
+  id: BartenderDrinks
+  name: loadout-group-bartender-drinks
+  minLimit: 0
+  loadouts:
+  - BottleOfNothing


### PR DESCRIPTION
## Описание PR
Добавлена бутылка "Ничего" в лодаут бармена за час игры на миме.

## Почему / Баланс
Бутылку "Ничего" можно получить только при вмешательстве админов или мапперов. Постарался исправить эту проблему.

## Технические детали
Небольшое изменение в файле role_loadouts.yml

## Медиа
![image](https://github.com/user-attachments/assets/1db6dcd8-cb20-47d5-b00b-ddcf661cf052)

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
- add: Добавлена бутылка "Ничего" в лодаут бармена за час игры на миме.