### PR TITLE
Исправление ошибки с кремнеплазовой платой

### DIFF
--- a/Resources/Prototypes/Victoria/Electron/RawCircuitBord.yml
+++ b/Resources/Prototypes/Victoria/Electron/RawCircuitBord.yml
@@ -556,9 +556,6 @@
   - type: PhysicalComposition
     materialComposition:
       SiPlazCircuitBordMaterial: 1000
-  - type: Tag
-    tags:
-    - SiPlazCircuitBord
 #------------------Стак--------------------------
 - type: stack
   id: SiPlazCircuitBord


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Исправление ошибки из-за которой нельзя поместить кремнеплазовую плату в принтер схем

## Почему / Баланс
Чтобы отдел исследований и разработок смог создавать платы, связанные с наукой

## Технические детали
Удаление тэга, ломающего вайт-лист для кремнеплазовой платы в принтере схем

## Требования
- [X] Не требует демонстрации в игре.
