### PR TITLE
Fix bayonets!

### DIFF
--- a/Resources/Prototypes/Victoria/Mirt/mirt.yml
+++ b/Resources/Prototypes/Victoria/Mirt/mirt.yml
@@ -1554,7 +1554,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -1617,7 +1621,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -1682,7 +1690,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -1748,7 +1760,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -1871,7 +1887,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -2090,7 +2110,11 @@
   - type: StaticPrice
     price: 500
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -135
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -2168,7 +2192,11 @@
   - type: StaticPrice
     price: 500
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -2242,7 +2270,11 @@
   - type: StaticPrice
     price: 250
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -2315,7 +2347,11 @@
   - type: StaticPrice
     price: 750
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:
@@ -2387,7 +2423,11 @@
   - type: StaticPrice
     price: 500    
   - type: AltFireMelee
+    attackType: Heavy
   - type: MeleeWeapon
+    wideAnimationRotation: -90
+    angle: 0
+    animation: WeaponArcThrust
     attackRate: 1
     damage:
       types:


### PR DESCRIPTION
## Описание PR
Все миртанское оружие со штыками колет как копья, а не просто бьют.

## Почему / Баланс
Штыки должны колоть.

## Технические детали
Просто дополнены компоненты AltFireMelee и MeleeWeapon.

## Медиа
https://github.com/user-attachments/assets/a838f59f-91df-4e04-9396-35c11df92a14


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
Отсутствуют

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Штыки на миртанском оружии теперь колют!

