### PR TITLE
No more ghostrole for Defense xeno

### DIFF
--- a/Resources/Prototypes/Victoria/DefenseMode/Xeno.yml
+++ b/Resources/Prototypes/Victoria/DefenseMode/Xeno.yml
@@ -215,6 +215,8 @@
   parent: MobXeno
   id: MobXenoDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: NpcFactionMember
     factions:
     - XenoTunnellerOnly
@@ -258,6 +260,8 @@
   parent: MobXeno
   id: MobXenoDefAlfaAlter
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -351,6 +355,8 @@
   parent: MobXenoPraetorian
   id: MobXenoPraetorianDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -409,6 +415,8 @@
   parent: MobXenoDrone
   id: MobXenoDroneDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -467,6 +475,8 @@
   parent: MobXenoQueen
   id: MobXenoQueenDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -530,6 +540,8 @@
   parent: MobXenoRavager
   id: MobXenoRavagerDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -579,6 +591,8 @@
   parent: MobXenoRavager
   id: MobXenoRavagerDefAlfaAlter
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: HTN
@@ -668,6 +682,8 @@
   parent: MobXenoRunner
   id: MobXenoRunnerDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -714,6 +730,8 @@
   parent: MobXenoRunner
   id: MobXenoRunnerDefAlfaAlter
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -805,6 +823,8 @@
   parent: MobXenoRouny
   id: MobXenoRounyDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -862,6 +882,8 @@
   parent: MobXenoSpitter
   id: MobXenoSpitterDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy

--- a/Resources/Prototypes/Victoria/DefenseMode/Xeno.yml
+++ b/Resources/Prototypes/Victoria/DefenseMode/Xeno.yml
@@ -216,7 +216,7 @@
   id: MobXenoDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: NpcFactionMember
     factions:
     - XenoTunnellerOnly
@@ -261,7 +261,7 @@
   id: MobXenoDefAlfaAlter
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -356,7 +356,7 @@
   id: MobXenoPraetorianDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -416,7 +416,7 @@
   id: MobXenoDroneDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -476,7 +476,7 @@
   id: MobXenoQueenDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -541,7 +541,7 @@
   id: MobXenoRavagerDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -592,7 +592,7 @@
   id: MobXenoRavagerDefAlfaAlter
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: HTN
@@ -683,7 +683,7 @@
   id: MobXenoRunnerDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -731,7 +731,7 @@
   id: MobXenoRunnerDefAlfaAlter
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: NpcFactionMember
     factions:
     - XenoTunneller
@@ -824,7 +824,7 @@
   id: MobXenoRounyDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy
@@ -883,7 +883,7 @@
   id: MobXenoSpitterDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Journey
     journeyGroup: Alpha
   - type: DefenseEnemy

--- a/Resources/Prototypes/Victoria/DefenseMode/Xeno_Special.yml
+++ b/Resources/Prototypes/Victoria/DefenseMode/Xeno_Special.yml
@@ -61,7 +61,7 @@
   id: MobXenoStiefmutterAlpha
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Sprite
     drawdepth: Mobs
     sprite: Victoria/DefenseMode/Xenos/stiefmutter.rsi
@@ -139,7 +139,7 @@
   id: MobXenoSaberDefAlfa
   components:
   - type: GhostRole
-    prob: 0.00
+    prob: 0
   - type: Sprite
     drawdepth: Mobs
     sprite: Victoria/DefenseMode/Xenos/saber.rsi

--- a/Resources/Prototypes/Victoria/DefenseMode/Xeno_Special.yml
+++ b/Resources/Prototypes/Victoria/DefenseMode/Xeno_Special.yml
@@ -60,6 +60,8 @@
   parent: MobXeno
   id: MobXenoStiefmutterAlpha
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Sprite
     drawdepth: Mobs
     sprite: Victoria/DefenseMode/Xenos/stiefmutter.rsi
@@ -136,6 +138,8 @@
   parent: MobXenoRavager
   id: MobXenoSaberDefAlfa
   components:
+  - type: GhostRole
+    prob: 0.00
   - type: Sprite
     drawdepth: Mobs
     sprite: Victoria/DefenseMode/Xenos/saber.rsi


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Ксеноморфы режима больше не спавнятся гостролями.

## Почему / Баланс
Зачем иметь странные правила если можно решить проблему?

## Технические детали
Каждой альфе и альтернативной альфе ксеноморфа, из режима обороны, добавлен компонент на нулевой шанс гостроли.

## Медиа
<img width="796" height="571" alt="NoGhost" src="https://github.com/user-attachments/assets/39ff0569-68c3-49ad-94c1-928e8d0ac52f" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
Отсутствуют

**Список изменений**

:cl:
- fix: Ксеноморфы из режима обороны больше не являются гост ролями!

